### PR TITLE
Add GitHub login support via Streamlit OAuth

### DIFF
--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -37,3 +37,8 @@ KAGGLE_KEY=""
 
 [dogBreedClassificationModel]
 MODEL="1O0vm50puB3FpWWpS53mB1_FazCRJXjvp"
+
+[auth.github]
+client_id = "Ov23lisz2ZiF2EVsQLz7"
+client_secret = "1b6810ecbf9819538f41f9e0634b5e8b21c7bbcf"
+redirect_uri = "https://jarvis-ai-assistant.streamlit.app/auth"

--- a/src/apps/auth/auth.py
+++ b/src/apps/auth/auth.py
@@ -6,26 +6,34 @@ import pytz
 from src.utils.greeting import GreetUser
 
 def unix_to_ist(timestamp):
-  india_tz = pytz.timezone('Asia/Kolkata')
-  format_str = '%I:%M:%S %p IST'
-  return datetime.fromtimestamp(timestamp, pytz.utc).astimezone(india_tz).strftime(format_str)
+    india_tz = pytz.timezone('Asia/Kolkata')
+    format_str = '%I:%M:%S %p IST'
+    return datetime.fromtimestamp(timestamp, pytz.utc).astimezone(india_tz).strftime(format_str)
 
 def auth():
-  if st.user and not st.user.is_logged_in:
-    st.title("🔐 Login Required")
-    st.write("Please authenticate using your Google account to access your profile.")
-    if st.button("🔓 Authenticate with Google"):
-      st.login("google")
+    if st.user and not st.user.is_logged_in:
+        st.title("🔐 Login Required")
+        st.write("Please authenticate using your preferred account to access your profile.")
 
-  else:
-    st.title(f"🙏 {GreetUser(st.user.given_name)}")
-    st.success("Welcome to Jarvis AI Assistant!", icon="🤝")
-    st.image(st.user.picture, caption=st.user.name)
-    st.write("Email:", st.user.email)
+        # Dual login options: Google and GitHub
+        col1, col2 = st.columns(2)
+        with col1:
+            if st.button("🔓 Login with Google"):
+                st.login("google")
 
-    if st.button("Log out"):
-      st.toast(f"Goodbye, {st.user.name}! See you soon!", icon="🚪")
-      sleep(2)
-      st.logout()
+        with col2:
+            if st.button("🐱 Login with GitHub"):
+                st.login("github")
+
+    else:
+        st.title(f"🙏 {GreetUser(st.user.given_name)}")
+        st.success("Welcome to Jarvis AI Assistant!", icon="🤝")
+        st.image(st.user.picture, caption=st.user.name)
+        st.write("Email:", st.user.email)
+
+        if st.button("Log out"):
+            st.toast(f"Goodbye, {st.user.name}! See you soon!", icon="🚪")
+            sleep(2)
+            st.logout()
 
 auth()


### PR DESCRIPTION
<!-- #302   -->
Closes: #302 

### GitHub Login Integration via Streamlit OAuth

This PR adds support for GitHub based login to the Jarvis AI Assistant alongside the existing Google login.

#### What’s Added:
- Dual authentication in `auth.py` using `st.login("google")` and `st.login("github")`
- Clean UI with side by side login buttons for better user experience
- Updates to `secrets.example.toml`:
- Added `[auth.github]` section with required fields for contributors

#### Tested:
- Locally tested on `streamlit run jarvis.py`
- GitHub login flow works as expected
- Logout works properly

Kindly check and confirm if everything looks correct. 

Let me know if any improvements or refactoring is needed.